### PR TITLE
[10.0][FIX] l10n_nl_country_states. contry_id -> country_id in tests.

### DIFF
--- a/l10n_nl_country_states/tests/test_l10n_nl_country_states.py
+++ b/l10n_nl_country_states/tests/test_l10n_nl_country_states.py
@@ -15,13 +15,13 @@ class TestL10nNlCountryStates(TransactionCase):
             self.env.ref('l10n_nl_country_states.state_noordholland'),
         )
         partner.write({'name': 'Therp BV'})
-        partner.write({'contry_id': self.env.ref('base.be').id})
+        partner.write({'country_id': self.env.ref('base.be').id})
         self.assertEqual(
             partner.state_id,
             self.env.ref('l10n_nl_country_states.state_noordholland'),
         )
         partner.write({
-            'contry_id': self.env.ref('base.nl').id,
+            'country_id': self.env.ref('base.nl').id,
             'zip': '9711LM',
         })
         self.assertEqual(


### PR DESCRIPTION
Also was wondering about the change of name (Therp -> Therp BV in test), and the first setting of country_id to Belgium. 